### PR TITLE
Prevent archived products from showing in search

### DIFF
--- a/imports/plugins/included/search-mongo/server/hooks/search.js
+++ b/imports/plugins/included/search-mongo/server/hooks/search.js
@@ -69,7 +69,9 @@ Products.after.update((userId, doc, fieldNames) => {
     if (modifiedFields.length) {
       Logger.debug(`Rewriting search record for ${doc.title}`);
       ProductSearch.remove(productId);
-      buildProductSearchRecord(productId);
+      if (!doc.isDeleted) { // do not create record if product was archived
+        buildProductSearchRecord(productId);
+      }
     } else {
       Logger.debug("No watched fields modified, skipping");
     }


### PR DESCRIPTION
[[[ Test PR on my fork.]]]

- [x] Description explains the issue / use-case resolved
Fixes [1730](https://github.com/reactioncommerce/reaction/issues/1730) Expected behavior: Once a product is archived, it should no longer appear in product search.

**Steps to test:**

1. Create a product and publish. Confirm that it shows when you search for the product.
2. Archive the product, then confirm that the product does not show again when searched for.
3. Add other products and confirm that search still works as before.

- [x] Only contains code directly related to the issue
- [x] Passes all tests
- [x] Has been linted and follows the style guide
